### PR TITLE
Add continuous integration pipeline using GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: [ master, ci ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk-version: [11]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Java ${{ matrix.jdk-version }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.jdk-version }}
+
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Build with Maven
+      run: mvn -B package

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ShieldDB
 
+![Build](https://github.com/kuroidoruido/ShieldDB/workflows/Build/badge.svg)
+    
 ShieldDB is a simple embedded database with JSON file backend with optional in-memory read cache.
 
 ## Features


### PR DESCRIPTION
* Set up continous integration using GitHub actions to build and test the maven project
* Trigger build pipeline on push event (only on the master branch) and on pull request event
* Show the build status into the README